### PR TITLE
feat: add dark/light mode toggle with persistent theme support

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -16,6 +16,62 @@
   --dark-gray: #6c757d;
 }
 
+/* Dark Mode Overrides - Only text, backgrounds, and shadows */
+body.dark {
+  color: #fff;
+  background-color: #000;
+}
+
+body.dark .App {
+  background-color: #000;
+  color: #fff;
+}
+
+body.dark .app-content {
+  background-color: #000;
+}
+
+body.dark h1,
+body.dark h2,
+body.dark h3,
+body.dark h4,
+body.dark h5,
+body.dark h6 {
+  color: #fff;
+}
+
+/* Override box-shadows to use white instead of black */
+body.dark *[style*="box-shadow"] {
+  box-shadow: 0 4px 15px rgba(255, 255, 255, 0.1) !important;
+}
+
+body.dark .navbar {
+  box-shadow: 0 4px 15px rgba(255, 255, 255, 0.1);
+}
+
+/* Footer Protection - Ensure footer remains completely untouched by theme changes */
+body.dark .footer,
+body.light .footer {
+  /* Preserve original footer styling */
+  background: linear-gradient(0deg, rgba(37, 22, 80, 1) 0%, rgba(55, 42, 114, 1) 100%) !important;
+  color: #fff !important;
+}
+
+body.dark .footer *,
+body.light .footer * {
+  /* Ensure all footer elements maintain their original styling */
+  color: inherit !important;
+}
+
+body.dark .footer-accent,
+body.light .footer-accent {
+  /* Preserve footer gradient text */
+  background: linear-gradient(90deg, #ff9a8b 0%, #ff6b8b 100%) !important;
+  -webkit-background-clip: text !important;
+  background-clip: text !important;
+  color: transparent !important;
+}
+
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -23,21 +79,28 @@ body {
   color: var(--text-color);
   background-color: #ffffff;
   line-height: 1.5;
+  transition: all 0.3s ease;
 }
 
 .App {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  background-color: #ffffff;
+  color: var(--text-color);
+  transition: all 0.3s ease;
 }
 
 .app-content {
   flex: 1;
+  background-color: #ffffff;
+  transition: all 0.3s ease;
 }
 
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
   line-height: 1.2;
+  color: var(--text-color);
 }
 
 a {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,10 +8,12 @@ import Dashboard from './pages/Dashboard';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import HomePage from './pages/HomePage';
+
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [userProfile, setUserProfile] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [theme, setTheme] = useState('light');
 
   // Set up axios defaults for authentication
   useEffect(() => {
@@ -19,6 +21,13 @@ function App() {
     if (token) {
       axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
     }
+  }, []);
+
+  // Load theme from localStorage on app start
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    setTheme(savedTheme);
+    document.body.className = savedTheme;
   }, []);
 
   useEffect(() => {
@@ -75,6 +84,13 @@ function App() {
     delete axios.defaults.headers.common['Authorization'];
   };
 
+  const handleThemeToggle = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+    document.body.className = newTheme;
+  };
+
   if (loading) {
     // You can add a loading spinner here
     return <div className="loading-container">Loading...</div>;
@@ -82,8 +98,14 @@ function App() {
 
   return (
     <Router>
-      <div className="App">
-        <Navbar isLoggedIn={isLoggedIn} userProfile={userProfile} onLogout={handleLogout} />
+      <div className={`App ${theme}`}>
+        <Navbar 
+          isLoggedIn={isLoggedIn} 
+          userProfile={userProfile} 
+          onLogout={handleLogout}
+          theme={theme}
+          onThemeToggle={handleThemeToggle}
+        />
         <main className="app-content">
           <Routes>
             <Route path="/" element={<HomePage />} />

--- a/client/src/components/Navbar.css
+++ b/client/src/components/Navbar.css
@@ -339,4 +339,141 @@
     margin: 0 auto;
     justify-content: center;
   }
+}
+
+/* Theme Toggle Button */
+.theme-toggle-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  margin-left: 10px;
+}
+
+.theme-toggle-btn:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  transform: scale(1.1);
+}
+
+/* Dark Mode Overrides - Only text and backgrounds */
+body.dark .navbar {
+  background: #000;
+  box-shadow: 0 4px 15px rgba(255, 255, 255, 0.1);
+}
+
+body.dark .navbar-logo {
+  color: #fff;
+}
+
+body.dark .menu-icon {
+  color: #fff;
+}
+
+body.dark .nav-link {
+  color: #fff;
+}
+
+body.dark .nav-link:hover {
+  color: #fff;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+body.dark .login-btn {
+  background-color: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+body.dark .login-btn:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+body.dark .profile-button {
+  background-color: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+body.dark .profile-button:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+body.dark .profile-name {
+  color: #fff;
+}
+
+body.dark .dropdown-arrow {
+  color: #fff;
+}
+
+body.dark .theme-toggle-btn {
+  color: #fff;
+}
+
+body.dark .theme-toggle-btn:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Light Mode Overrides - Only text and backgrounds */
+body.light .navbar {
+  background: linear-gradient(90deg, #ffffff 0%, #f8f9fa 100%);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+body.light .navbar-logo {
+  color: #333;
+}
+
+body.light .menu-icon {
+  color: #333;
+}
+
+body.light .nav-link {
+  color: #333;
+}
+
+body.light .nav-link:hover {
+  color: #333;
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+body.light .login-btn {
+  background-color: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  color: #333;
+}
+
+body.light .login-btn:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+body.light .profile-button {
+  background-color: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+body.light .profile-button:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+body.light .profile-name {
+  color: #333;
+}
+
+body.light .dropdown-arrow {
+  color: #333;
+}
+
+body.light .theme-toggle-btn {
+  color: #333;
+}
+
+body.light .theme-toggle-btn:hover {
+  background-color: rgba(0, 0, 0, 0.05);
 } 

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import './Navbar.css';
 import { IoMenuOutline, IoCloseOutline } from 'react-icons/io5';
-import { FaUser, FaSignOutAlt, FaUserCircle, FaChevronDown } from 'react-icons/fa';
+import { FaUser, FaSignOutAlt, FaChevronDown } from 'react-icons/fa';
+import { BsSun, BsMoon } from 'react-icons/bs';
 
-const Navbar = ({ isLoggedIn, userProfile, onLogout }) => {
+const Navbar = ({ isLoggedIn, userProfile, onLogout, theme, onThemeToggle }) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const navigate = useNavigate();
@@ -61,6 +62,17 @@ const Navbar = ({ isLoggedIn, userProfile, onLogout }) => {
               </Link>
             </li>
           )}
+
+          {/* Theme Toggle Button */}
+          <li className="nav-item">
+            <button 
+              className="theme-toggle-btn" 
+              onClick={onThemeToggle}
+              aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+            >
+              {theme === 'light' ? <BsMoon /> : <BsSun />}
+            </button>
+          </li>
           
           {!isLoggedIn ? (
             <>

--- a/client/src/pages/HomePage.css
+++ b/client/src/pages/HomePage.css
@@ -404,4 +404,71 @@ section {
   .cta-title {
     font-size: 2rem;
   }
+}
+
+/* Dark Mode Overrides */
+body.dark .hero-title {
+  color: #fff;
+}
+
+body.dark .hero-description {
+  color: #ccc;
+}
+
+body.dark .section-title {
+  color: #fff;
+}
+
+body.dark .section-subtitle {
+  color: #ccc;
+}
+
+body.dark .feature-card {
+  background: #1a1a1a;
+  box-shadow: 0 10px 30px rgba(255, 255, 255, 0.05);
+}
+
+body.dark .features-section {
+  background: linear-gradient(0deg, rgba(37, 22, 80, 1) 0%, rgba(55, 42, 114, 1) 100%);
+}
+
+body.dark .how-section {
+  background: #000;
+}
+
+body.dark .feature-card:hover {
+  box-shadow: 0 15px 35px rgba(255, 255, 255, 0.08);
+}
+
+body.dark .feature-title {
+  color: #fff;
+}
+
+body.dark .feature-description {
+  color: #ccc;
+}
+
+body.dark .step-title {
+  color: #fff;
+}
+
+body.dark .step-description {
+  color: #ccc;
+}
+
+body.dark .cta-title {
+  color: #fff;
+}
+
+body.dark .cta-description {
+  color: #ccc;
+}
+
+body.dark .btn-secondary {
+  color: #fff;
+  border: 1px solid #444;
+}
+
+body.dark .btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.05);
 } 

--- a/client/src/pages/auth.css
+++ b/client/src/pages/auth.css
@@ -326,3 +326,155 @@
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   }
   
+/* Dark Mode Overrides for Auth Pages */
+body.dark .auth-container {
+  background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
+}
+
+body.dark .auth-container.login-mode {
+  background: linear-gradient(135deg, #2d1b3d 0%, #1a1a1a 100%);
+}
+
+body.dark .auth-container.register-mode {
+  background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
+}
+
+body.dark .auth-card {
+  background: #2d2d2d;
+  box-shadow: 0 10px 30px rgba(255, 255, 255, 0.1);
+}
+
+body.dark .auth-title {
+  color: #fff;
+}
+
+body.dark .form-input {
+  background: #1a1a1a;
+  border: 2px solid #444;
+  color: #fff;
+}
+
+body.dark .form-input:focus {
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+}
+
+body.dark .form-input::placeholder {
+  color: #888;
+}
+
+body.dark .eye-toggle {
+  color: #667eea;
+}
+
+body.dark .auth-error {
+  color: #ff6b6b;
+}
+
+body.dark .auth-success {
+  color: #51cf66;
+}
+
+body.dark .toggle-text {
+  color: #ccc;
+}
+
+body.dark .toggle-button {
+  color: #667eea;
+}
+
+body.dark .toggle-button:hover {
+  color: #8b9eff;
+}
+
+/* Preserve gradient elements */
+body.dark .auth-button {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+body.dark .auth-button:hover {
+  box-shadow: 0 6px 15px rgba(102, 126, 234, 0.3);
+}
+
+/* Additional dark mode styles for other auth elements */
+body.dark .auth-logo {
+  color: #fff;
+}
+
+body.dark .auth-logo-accent {
+  background: linear-gradient(90deg, #ff6b8b 0%, #a56bff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+body.dark .auth-header h2 {
+  color: #fff;
+}
+
+body.dark .auth-header p {
+  color: #ccc;
+}
+
+body.dark .form-field label {
+  color: #ccc;
+}
+
+body.dark .form-field input {
+  background: #1a1a1a;
+  border: 1px solid #444;
+  color: #fff;
+}
+
+body.dark .form-field input:focus {
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+}
+
+body.dark .password-toggle {
+  color: #667eea;
+}
+
+body.dark .password-toggle:hover {
+  color: #8b9eff;
+}
+
+body.dark .error-message {
+  color: #ff6b6b;
+}
+
+body.dark .server-error {
+  background-color: rgba(255, 107, 107, 0.1);
+  color: #ff6b6b;
+}
+
+body.dark .server-success {
+  background-color: rgba(81, 207, 102, 0.1);
+  color: #51cf66;
+}
+
+body.dark .form-terms {
+  color: #ccc;
+}
+
+body.dark .terms-link {
+  color: #667eea;
+}
+
+body.dark .terms-link:hover {
+  color: #8b9eff;
+}
+
+body.dark .auth-footer {
+  color: #ccc;
+}
+
+body.dark .auth-link {
+  color: #667eea;
+}
+
+body.dark .auth-link:hover {
+  color: #8b9eff;
+}
+  


### PR DESCRIPTION

FixTime now supports dark and light themes, giving users the flexibility to choose what’s easier on their eyes.

## What’s new:
- Theme toggle added to the navbar (with sun/moon icons)
- Theme preference saved using localStorage
- Full dark mode styles added across all major components
- Gradient elements stay vibrant across both themes
- Footer kept theme-agnostic intentionally

## Updated files:
- App.js / App.css: theme state, storage, and global styles
- Navbar.jsx / Navbar.css: toggle UI and adaptive styles
- HomePage.css, auth.css: full dark mode support for pages

## Notes:
- Theme persists across sessions
- Responsive layout works in both modes
- Smooth transitions when toggling themes
- Tested on all pages for consistency

Closes #theme-toggle-request