### PR TITLE
Fix: Ensure services are seeded with valid providerId

### DIFF
--- a/client/src/pages/AppointmentCalendar.css
+++ b/client/src/pages/AppointmentCalendar.css
@@ -803,6 +803,13 @@ body.dark .cancel-btn:hover {
   background-color: var(--error-bg-dark, rgba(239, 68, 68, 0.15));
 }
 
+.reschedule-btn:disabled,
+.cancel-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  filter: grayscale(0.5);
+}
+
 .calendar-notification {
   position: fixed;
   bottom: 2rem;

--- a/client/src/pages/AppointmentCalendar.jsx
+++ b/client/src/pages/AppointmentCalendar.jsx
@@ -8,6 +8,7 @@ import { FaFilter, FaCalendarDay, FaTimes, FaEdit, FaTrash, FaMapMarkerAlt, FaBu
 import { motion, AnimatePresence } from 'framer-motion';
 import axios from 'axios';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { isPastAppointment } from '../utils/serviceUtils';
 
 const AppointmentCalendar = () => {
   const [appointments, setAppointments] = useState([]);
@@ -527,12 +528,16 @@ const AppointmentCalendar = () => {
                     <button 
                       className="reschedule-btn"
                       onClick={() => rescheduleAppointment(selectedAppointment._id)}
+                      disabled={isPastAppointment(selectedAppointment.date, selectedAppointment.time)}
+                      title={isPastAppointment(selectedAppointment.date, selectedAppointment.time) ? 'Cannot reschedule past appointments' : ''}
                     >
                       <FaEdit /> Reschedule
                     </button>
                     <button 
                       className="cancel-btn"
                       onClick={() => cancelAppointment(selectedAppointment._id)}
+                      disabled={isPastAppointment(selectedAppointment.date, selectedAppointment.time)}
+                      title={isPastAppointment(selectedAppointment.date, selectedAppointment.time) ? 'Cannot cancel past appointments' : ''}
                     >
                       <FaTrash /> Cancel
                     </button>

--- a/client/src/pages/MyAppointments.jsx
+++ b/client/src/pages/MyAppointments.jsx
@@ -18,6 +18,7 @@ import {
   FaExclamationTriangle
 } from 'react-icons/fa';
 import './MyAppointments.css';
+import { isPastAppointment } from '../utils/serviceUtils';
 
 const MyAppointments = () => {
   const [appointments, setAppointments] = useState([]);
@@ -641,7 +642,7 @@ const MyAppointments = () => {
                     <FaEye />
                     View Details
                   </button>
-                  {(appointment.status === 'scheduled' || appointment.status === 'confirmed') && (
+                  {(appointment.status === 'scheduled' || appointment.status === 'confirmed') && !isPastAppointment(appointment.date, appointment.time) && (
                     <>
                     <button 
                       className="reschedule-btn"
@@ -754,7 +755,7 @@ const MyAppointments = () => {
             </div>
 
             <div className="modal-footer">
-              {(selectedAppointment.status === 'scheduled' || selectedAppointment.status === 'confirmed') && (
+              {(selectedAppointment.status === 'scheduled' || selectedAppointment.status === 'confirmed') && !isPastAppointment(selectedAppointment.date, selectedAppointment.time) && (
                 <>
                 <button 
                   className="reschedule-btn"

--- a/client/src/utils/serviceUtils.js
+++ b/client/src/utils/serviceUtils.js
@@ -34,3 +34,21 @@ export const fetchServiceRating = async (serviceId) => {
     return { avgRating: 0, totalReviews: 0 };
   }
 }; 
+
+/**
+ * Checks if an appointment is in the past (date and time)
+ * @param {string|Date} date - The appointment date (string or Date)
+ * @param {string} time - The appointment time (e.g., '10:30 AM')
+ * @returns {boolean} - True if the appointment is in the past
+ */
+export function isPastAppointment(date, time) {
+  const now = new Date();
+  const apptDate = new Date(date);
+  if (!time) return apptDate < now; // fallback if time missing
+  const [rawTime, period] = time.split(' ');
+  let [hours, minutes] = rawTime.split(':').map(Number);
+  if (period === 'PM' && hours !== 12) hours += 12;
+  if (period === 'AM' && hours === 12) hours = 0;
+  apptDate.setHours(hours, minutes, 0, 0);
+  return apptDate < now;
+} 

--- a/server/src/controllers/appointmentController.js
+++ b/server/src/controllers/appointmentController.js
@@ -468,6 +468,14 @@ exports.updateAppointmentStatus = async (req, res) => {
       });
     }
 
+    // Prevent status update if appointment is in the past
+    if (isPastAppointment(appointment.date, appointment.time)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Cannot update status of a past appointment.'
+      });
+    }
+
     // Update status
     appointment.status = status;
     await appointment.save();
@@ -565,6 +573,14 @@ exports.rescheduleAppointment = async (req, res) => {
       });
     }
 
+    // Prevent rescheduling if appointment is in the past
+    if (isPastAppointment(appointment.date, appointment.time)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Cannot reschedule a past appointment.'
+      });
+    }
+
     // Update appointment
     appointment.date = date;
     appointment.time = time;
@@ -589,3 +605,16 @@ exports.rescheduleAppointment = async (req, res) => {
     });
   }
 }; 
+
+// Utility: Check if appointment is in the past
+function isPastAppointment(date, time) {
+  const now = new Date();
+  const apptDate = new Date(date);
+  if (!time) return apptDate < now;
+  const [rawTime, period] = time.split(' ');
+  let [hours, minutes] = rawTime.split(':').map(Number);
+  if (period === 'PM' && hours !== 12) hours += 12;
+  if (period === 'AM' && hours === 12) hours = 0;
+  apptDate.setHours(hours, minutes, 0, 0);
+  return apptDate < now;
+} 


### PR DESCRIPTION
Fix: Prevent Actions on Past Appointments
What was fixed:
Users can no longer reschedule or cancel appointments that are in the past.
The frontend disables or hides reschedule/cancel buttons for past appointments.
The backend now blocks API requests to reschedule or cancel past appointments, returning a clear error message.
